### PR TITLE
Rescue if response body is not a valid JSON string

### DIFF
--- a/lib/godaddy/api.rb
+++ b/lib/godaddy/api.rb
@@ -21,7 +21,11 @@ module Godaddy
         http.use_ssl = true
         request = build_request method, uri, payload
         response = http.request(request)
-        result = JSON.parse(response.body)
+        begin
+          result = JSON.parse(response.body)
+        rescue
+          result = response.body
+        end
 
         fail APIError, result unless response.is_a?(Net::HTTPSuccess)
 


### PR DESCRIPTION
Godaddy may return empty string (e.g, when request is successful)